### PR TITLE
Fixed anndata neighbors key issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,10 @@
 # VeloVAE - Variational Mixtures of ODEs for Inferring Cellular Gene Expression Dynamics
-## Introduction
+# JJ fork
+## Made fork to fix some issues with Scanpy/Anndata version
+### Reference issue [#6](https://github.com/welch-lab/VeloVAE/issues/6)
 
-The rapid growth of scRNA-seq data has spurred many advances in single-cell analysis. A key problem is to understand how gene expression changes during cell development. Recently, RNA velocity provided a new way to study gene expression from a dynamical system point of view. Because cells are destroyed during measurement, any scRNA-seq data are just one or very few static snapshots of mRNA count matrices. This makes it hard to learn the gene expression kinetics, as the time information is lost.
-
-VeloVAE is a deep generative model for learning gene expression dynamics from scRNA-seq data. The purpose of our method is to infer latent cell time and velocity simultaneously. This is achieved by using variational Bayesian inference with neural networks. VeloVAE is based on the biochemical process of converting nascent mRNA molecules to mature ones via splicing. The generative model is constrained by a set of ordinary differential equations. VeloVAE is capable of handling more complex gene expression kinetics compared with previous methods.
-
-## Package Usage
-The package depends on several main-stream packages in computational biology and machine learning, including [scanpy](https://scanpy.readthedocs.io/en/stable/), [PyTorch](https://pytorch.org/), [scikit-learn](https://scikit-learn.org/stable/). We suggest using a GPU to accelerate the training process.
-
-A sample jupyter notebook is available [here](notebooks/velovae_example.ipynb). Notice that the dataset in the example is from [scVelo](https://scvelo.readthedocs.io/), so you would need to install scVelo.
-
-The package has not been submitted to PyPI yet, but you can download it and import the package locally by adding the path of the package to the system path:
-```python
-import sys
-sys.path.append(< path to the package >)
-import velovae
+Current error is that `evaluation_utils.py` calls for `adata.uns['neighbors']['indices']` but this structure is no longer retained in newer versions of Scanpy and Anndata. To address this issue, I made some adjustments to the code as the current output from `adata.uns['neighbors'].keys()` is 
 ```
-We also plan to make the package available on PyPI soon.
+dict_keys(['connectivities_key', 'distances_key', 'params'])
+```
+where the indices are called in the `connectivities_key`. I don't know what version of Scanpy, ScVelo, and Anndata could be causing the issue but I have introduced a temporary fix to the problem until the repository owners can fix it. 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,23 @@
 # VeloVAE - Variational Mixtures of ODEs for Inferring Cellular Gene Expression Dynamics
+## Introduction
+
+The rapid growth of scRNA-seq data has spurred many advances in single-cell analysis. A key problem is to understand how gene expression changes during cell development. Recently, RNA velocity provided a new way to study gene expression from a dynamical system point of view. Because cells are destroyed during measurement, any scRNA-seq data are just one or very few static snapshots of mRNA count matrices. This makes it hard to learn the gene expression kinetics, as the time information is lost.
+
+VeloVAE is a deep generative model for learning gene expression dynamics from scRNA-seq data. The purpose of our method is to infer latent cell time and velocity simultaneously. This is achieved by using variational Bayesian inference with neural networks. VeloVAE is based on the biochemical process of converting nascent mRNA molecules to mature ones via splicing. The generative model is constrained by a set of ordinary differential equations. VeloVAE is capable of handling more complex gene expression kinetics compared with previous methods.
+
+## Package Usage
+The package depends on several main-stream packages in computational biology and machine learning, including [scanpy](https://scanpy.readthedocs.io/en/stable/), [PyTorch](https://pytorch.org/), [scikit-learn](https://scikit-learn.org/stable/). We suggest using a GPU to accelerate the training process.
+
+A sample jupyter notebook is available [here](notebooks/velovae_example.ipynb). Notice that the dataset in the example is from [scVelo](https://scvelo.readthedocs.io/), so you would need to install scVelo.
+
+The package has not been submitted to PyPI yet, but you can download it and import the package locally by adding the path of the package to the system path:
+```python
+import sys
+sys.path.append(< path to the package >)
+import velovae
+```
+We also plan to make the package available on PyPI soon.
+
 # JJ fork
 ## Made fork to fix some issues with Scanpy/Anndata version
 ### Reference issue [#6](https://github.com/welch-lab/VeloVAE/issues/6)

--- a/velovae/analysis/evaluation_util.py
+++ b/velovae/analysis/evaluation_util.py
@@ -1116,6 +1116,24 @@ def gen_cross_boundary_correctness(
 
             - :class:`numpy.ndarray`: Average score over all cells for all step numbers
     """
+      # Use k-hop neighbors
+    scores = {}
+    x_emb_name = x_emb
+    if x_emb in adata.obsm:
+        x_emb = adata.obsm[x_emb]
+        if x_emb_name == "X_umap":
+            v_emb = adata.obsm['{}_umap'.format(k_velocity)]
+        else:
+            v_emb = adata.obsm[[key for key in adata.obsm if key.startswith(k_velocity)][0]]
+    else:
+        x_emb = adata.layers[x_emb]
+        v_emb = adata.layers[k_velocity]
+        if gene_mask is None:
+            gene_mask = ~np.isnan(v_emb[0])
+        x_emb = x_emb[:, gene_mask]
+        v_emb = v_emb[:, gene_mask]
+    
+    
     # Get the connectivity matrix
     connectivities = adata.obsp[adata.uns['neighbors']['connectivities_key']]
     
@@ -1247,6 +1265,23 @@ def gen_cross_boundary_correctness_test(
 
             - :class:`numpy.ndarray`: Average Mann-Whitney U test statistics over all cells for all step numbers
     """
+    # Use k-hop neighbors
+    test_stats, accuracy = {}, {}
+    x_emb_name = x_emb
+    if x_emb in adata.obsm:
+        x_emb = adata.obsm[x_emb]
+        if x_emb_name == "X_umap":
+            v_emb = adata.obsm['{}_umap'.format(k_velocity)]
+        else:
+            v_emb = adata.obsm[[key for key in adata.obsm if key.startswith(k_velocity)][0]]
+    else:
+        x_emb = adata.layers[x_emb]
+        v_emb = adata.layers[k_velocity]
+        if gene_mask is None:
+            gene_mask = ~np.isnan(v_emb[0])
+        x_emb = x_emb[:, gene_mask]
+        v_emb = v_emb[:, gene_mask]
+
     # Get the connectivity matrix
     connectivities = adata.obsp[adata.uns['neighbors']['connectivities_key']]
     


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #6 
PR Number on Fork: fixed neighbors key bug [#1](https://github.com/welch-lab/VeloVAE/issues/6)

Current error status
```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[46], line 4
      2 keys = ['fullvb']
      3 grid_size = (1,2)
----> 4 res, res_type = vv.post_analysis(adata,
      5                                  'continuous',
      6                                  methods,
      7                                  keys,
      8                                  compute_metrics=True,
      9                                  raw_count=False,
     10                                  #genes=gene_plot,
     11                                  grid_size=(1,2),
     12                                  #figure_path=figure_path,
     13                                  cluster_key='celltype')

File ~/miniconda3/envs/velovae/lib/python3.10/site-packages/velovae/analysis/evaluation.py:455, in post_analysis(adata, test_id, methods, keys, gene_key, compute_metrics, raw_count, genes, plot_type, cluster_key, cluster_edges, nplot, frac, embed, grid_size, sparsity_correction, figure_path, save, **kwargs)
    453 for i, method in enumerate(methods):
    454     if compute_metrics:
--> 455         stats_i, stats_type_i = get_metric(adata,
    456                                            method,
    457                                            keys[i],
    458                                            vkeys[i],
    459                                            cluster_key,
    460                                            gene_key,
    461                                            cluster_edges,
    462                                            embed,
    463                                            n_jobs=(kwargs['n_jobs']
    464                                                    if 'n_jobs' in kwargs
    465                                                    else None))
    466         stats_type_list.append(stats_type_i)
    467         # avoid duplicate methods with different keys

File ~/miniconda3/envs/velovae/lib/python3.10/site-packages/velovae/analysis/evaluation.py:273, in get_metric(adata, method, key, vkey, cluster_key, gene_key, cluster_edges, embed, n_jobs)
    266 stats['Vel Consistency (Velocity Genes)'] = mean_vel_consistency_sub
    268 # Compute velocity metrics on all genes
    269 (iccoh, mean_iccoh,
    270  cbdir_embed, mean_cbdir_embed,
    271  cbdir, mean_cbdir,
    272  tscore, mean_tscore,
--> 273  mean_vel_consistency) = get_velocity_metric(adata,
    274                                              key,
    275                                              vkey,
    276                                              cluster_key,
    277                                              cluster_edges,
    278                                              None,
    279                                              embed,
    280                                              n_jobs)
    281 stats['CBDir (Embed)'] = mean_cbdir_embed
    282 stats['CBDir'] = mean_cbdir

File ~/miniconda3/envs/velovae/lib/python3.10/site-packages/velovae/analysis/evaluation.py:80, in get_velocity_metric(adata, key, vkey, cluster_key, cluster_edges, gene_mask, embed, n_jobs)
     35 def get_velocity_metric(adata,
     36                         key,
     37                         vkey,
   (...)
     41                         embed='umap',
     42                         n_jobs=None):
     43     """
     44     Computes Cross-Boundary Direction Correctness and In-Cluster Coherence.
     45     The function calls scvelo.tl.velocity_graph.
   (...)
     78             - float: Velocity Consistency
     79     """
---> 80     mean_constcy_score = velocity_consistency(adata, vkey, gene_mask)
     81     if cluster_edges is not None:
     82         try:

File ~/miniconda3/envs/velovae/lib/python3.10/site-packages/velovae/analysis/evaluation_util.py:1621, in velocity_consistency(adata, vkey, gene_mask)
   1607 def velocity_consistency(adata, vkey, gene_mask=None):
   1608     """Velocity Consistency as reported in scVelo paper
   1609 
   1610     Args:
   (...)
   1619         float: Average score over all cells.
   1620     """
-> 1621     nbs = adata.uns['neighbors']['indices']
   1623     velocities = adata.layers[vkey]
   1624     nan_mask = ~np.isnan(velocities[0]) if gene_mask is None else gene_mask

KeyError: 'indices'
```

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
Current version `evaluation_utils.py` calls the neighbor indices as `adata.uns['neighbors']['indices']`.
This doesn't work with newer versions of anndata and/or Scanpy where `adata.uns['neighbors'].keys()`
will print out:
```
dict_keys(['connectivities_key', 'distances_key', 'params'])
```
where the indices are inside of the `connectivities_key`. I found the offending behavior in the following functions:
1. velocity_consistency
2. inner_cluster_coh
3. cross_boundary_correctness
4. gen_cross_boundary_correctness
5. gen_cross_boundary_correctness_test
6. calibrated_cross_boundary_correctness
7. also added import to include csr_matrix from scipy.sparse

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Output from 
```
# Get all module names in the current namespace
module_names = set(sys.modules) & set(globals())

# Print the name and version of each module
for name in module_names:
    module = sys.modules[name]
    if hasattr(module, '__version__'):
        print(f"{name}=={module.__version__}")
    elif hasattr(module, 'VERSION'):
        print(f"{name}=={module.VERSION}")
    else:
        print(f"{name}")
```

```
logging==0.5.1.2
torch==2.3.1
math
random
warnings
textwrap
sys
anndata==0.10.7
os
cellrank==2.0.4
gc
```

Please let me know if you need anything else.